### PR TITLE
Update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@types/node": ">=10.13.0",
-    "axios": "^0.21.0"
+    "axios": ">=0.21.0"
   },
   "devDependencies": {
     "ava": "^3.0.0",


### PR DESCRIPTION
An update in axios@0.23.0 caused a change to TransitionalOptions typings in AxiosRequestConfig (https://github.com/axios/axios/pull/4147).

If your project uses axios >=0.23.0 with axiosist, using AxiosRequestConfig would cause a type error.

Usage:

```
import * as test from "mocha"
import axiosist from "axiosist"
import {AxiosRequestConfig} from "axios"
import {RequestListener} from "http"

export function basicHttpRequestTest(app: RequestListener, config: AxiosRequestConfig): void {
    test(config.method.toUpperCase() + " " + config.url, () => {
        let response

        it("request data", async() => {
            response = await axiosist(app).request(config)
        }).timeout(60000)
        
        // assert
    })
}
```

Error:
error TS2345: Argument of type 'AxiosRequestConfig<any>' is not assignable to parameter of type 'AxiosRequestConfig'.
  Types of property 'transitional' are incompatible.
    Type 'import("/Users/hzaun/xxx/functions/node_modules/axios/index").TransitionalOptions' is not assignable to type 'import("/Users/hzaun/xxx/functions/node_modules/axiosist/node_modules/axios/index").TransitionalOptions'.
      Property 'silentJSONParsing' is optional in type 'TransitionalOptions' but required in type 'TransitionalOptions'.